### PR TITLE
Added log to print remote URL

### DIFF
--- a/posix/clone-commit
+++ b/posix/clone-commit
@@ -6,8 +6,10 @@ if [[ ! -z "${PLUGIN_DEPTH}" ]]; then
 fi
 
 if [ ! -d .git ]; then
+	set -x
 	git init
 	git remote add origin ${DRONE_REMOTE_URL}
+	set +x
 fi
 
 # the branch may be empty for certain event types,

--- a/posix/clone-pull-request
+++ b/posix/clone-pull-request
@@ -6,8 +6,10 @@ if [[ ! -z "${PLUGIN_DEPTH}" ]]; then
 fi
 
 if [ ! -d .git ]; then
+	set -x
 	git init
 	git remote add origin ${DRONE_REMOTE_URL}
+	set +x
 fi
 
 # If PR clone strategy is cloning only the source branch

--- a/posix/clone-tag
+++ b/posix/clone-tag
@@ -6,8 +6,10 @@ if [[ ! -z "${PLUGIN_DEPTH}" ]]; then
 fi
 
 if [ ! -d .git ]; then
+	set -x
 	git init
 	git remote add origin ${DRONE_REMOTE_URL}
+	set +x
 fi
 
 set -e


### PR DESCRIPTION
Recently one customer faced an issue with gitlab account level ssh connectors.
Later on debugging we found out the repo name itself was wrong. But it took a lot of time to realise that. 

**This is what the git clone step log look in the failure scenario**

> {"level":"info","pos":0,"out":"Initialized empty Git repository in /harness/.git/\n","time":"2022-03-02T08:01:06.788338106Z","args":{}}
> {"level":"info","pos":1,"out":"+ git fetch '--depth=50' origin +refs/heads/main:\n","time":"2022-03-02T08:01:06.791613392Z","args":{}}
> {"level":"info","pos":2,"out":"load pubkey \"/root/.ssh/id_rsa\": invalid format\r\n","time":"2022-03-02T08:01:06.826892732Z","args":{}}
> {"level":"info","pos":3,"out":"Warning: Permanently added the ECDSA host key for IP address '172.65.251.78' to the list of known hosts.\r\n","time":"2022-03-02T08:01:06.975270544Z","args":{}}
> {"level":"info","pos":4,"out":"remote: \n","time":"2022-03-02T08:01:07.321712913Z","args":{}}
> {"level":"info","pos":5,"out":"remote: ========================================================================\n","time":"2022-03-02T08:01:07.321822397Z","args":{}}
> {"level":"info","pos":6,"out":"remote: \n","time":"2022-03-02T08:01:07.321855469Z","args":{}}
> {"level":"info","pos":7,"out":"remote: The namespace you were looking for could not be found.\n","time":"2022-03-02T08:01:07.321879608Z","args":{}}
> {"level":"info","pos":8,"out":"remote: \n","time":"2022-03-02T08:01:07.32190073Z","args":{}}
> {"level":"info","pos":9,"out":"remote: ========================================================================\n","time":"2022-03-02T08:01:07.321972897Z","args":{}}
> {"level":"info","pos":10,"out":"remote: \n","time":"2022-03-02T08:01:07.322070405Z","args":{}}
> {"level":"info","pos":11,"out":"fatal: Could not read from remote repository.\n","time":"2022-03-02T08:01:07.322894268Z","args":{}}
> {"level":"info","pos":12,"out":"\n","time":"2022-03-02T08:01:07.322973734Z","args":{}}
> {"level":"info","pos":13,"out":"Please make sure you have the correct access rights\n","time":"2022-03-02T08:01:07.323038531Z","args":{}}
> {"level":"info","pos":14,"out":"and the repository exists.\n","time":"2022-03-02T08:01:07.323160811Z","args":{}}
> 

Link to sample run : https://app.harness.io/ng/#/account/vpCkHKsDSxK9_KYfjCTMKA/ci/orgs/default/projects/CI_Sanity/pipelines/dev_ci_3558/executions/JMllZsxMSj2tYf9CV-Js1w/pipeline

It would be better if we could print the remote url also in the git clone step log. This pr is raised for that purpose.

**Failure scenario logs after the fix:**

> {"level":"info","pos":0,"out":"+ git init\n","time":"2022-03-02T08:08:31.62973245Z","args":{}}
> {"level":"info","pos":1,"out":"Initialized empty Git repository in /harness/.git/\n","time":"2022-03-02T08:08:31.650952288Z","args":{}}
> {"level":"info","pos":2,"out":"+ git remote add origin git@gitlab.com:devki.mittal/test.git.git\n","time":"2022-03-02T08:08:31.651297309Z","args":{}}
> {"level":"info","pos":3,"out":"+ set +x\n","time":"2022-03-02T08:08:31.671169837Z","args":{}}
> {"level":"info","pos":4,"out":"+ git fetch '--depth=50' origin +refs/heads/main:\n","time":"2022-03-02T08:08:31.671266162Z","args":{}}
> {"level":"info","pos":5,"out":"load pubkey \"/root/.ssh/id_rsa\": invalid format\r\n","time":"2022-03-02T08:08:31.704700135Z","args":{}}
> {"level":"info","pos":6,"out":"Warning: Permanently added the ECDSA host key for IP address '172.65.251.78' to the list of known hosts.\r\n","time":"2022-03-02T08:08:31.906417883Z","args":{}}
> {"level":"info","pos":7,"out":"remote: \n","time":"2022-03-02T08:08:32.381736185Z","args":{}}
> {"level":"info","pos":8,"out":"remote: ========================================================================\n","time":"2022-03-02T08:08:32.381930824Z","args":{}}
> {"level":"info","pos":9,"out":"remote: \n","time":"2022-03-02T08:08:32.381986828Z","args":{}}
> {"level":"info","pos":10,"out":"remote: The namespace you were looking for could not be found.\n","time":"2022-03-02T08:08:32.382037084Z","args":{}}
> {"level":"info","pos":11,"out":"remote: \n","time":"2022-03-02T08:08:32.382072564Z","args":{}}
> {"level":"info","pos":12,"out":"remote: ========================================================================\n","time":"2022-03-02T08:08:32.382087569Z","args":{}}
> {"level":"info","pos":13,"out":"remote: \n","time":"2022-03-02T08:08:32.382106213Z","args":{}}
> {"level":"info","pos":14,"out":"fatal: Could not read from remote repository.\n","time":"2022-03-02T08:08:32.383860048Z","args":{}}
> {"level":"info","pos":15,"out":"\n","time":"2022-03-02T08:08:32.383961873Z","args":{}}
> {"level":"info","pos":16,"out":"Please make sure you have the correct access rights\n","time":"2022-03-02T08:08:32.384042846Z","args":{}}
> {"level":"info","pos":17,"out":"and the repository exists.\n","time":"2022-03-02T08:08:32.384100876Z","args":{}}



CC : @harshjain12 