### PR TITLE
changed ubi image to 8.6-751

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-minimal:8.5-240.1648458092
+FROM redhat/ubi8-minimal:8.6-751
 RUN microdnf update && microdnf install ca-certificates git git-lfs openssh curl perl python38 shadow-utils
 RUN pip-3 install awscli
 

--- a/docker/Dockerfile.rootless.linux.amd64
+++ b/docker/Dockerfile.rootless.linux.amd64
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-minimal:8.5-240.1648458092
+FROM redhat/ubi8-minimal:8.6-751
 RUN microdnf update && microdnf install ca-certificates git git-lfs openssh curl perl python38 shadow-utils
 RUN pip-3 install awscli
 


### PR DESCRIPTION
The automation suite for drone-git is passing successfully with the new updated images.

Reason for image update:
1. Security Reference Ticket - https://harness.atlassian.net/browse/SECAPP-258
2. To meet Ironbank/on-premise federal requirements for storing harness images.