### PR TITLE
Updated docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ LICENSE
 README.md
 */fixtures*
 posix/*.go
+# Exclude specific file 'fixtures.sh' from being ignored
+!posix/fixtures.sh


### PR DESCRIPTION
How was it working earlier?
We were using builds via k8s and it was using kaniko, which somehow is not considering .dockerIgnore. Since we are moving the image build pipeline to harness0 with vm stages, it's failing there. And hence the change.
Failed pipeline https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/PROD/projects/CI/pipelines/droneGit/executions/Z7KCRDwGQ56BFbsNRrEz4w/pipeline?stage=n0bp3l29SGmjsSBEAFyXbQ&step=_f0QD3dQQFCTFM46ndBnqg&childStage=&stageExecId=
Verified in local as well