### PR TITLE
Updated win22 dockerfile

### DIFF
--- a/docker/Dockerfile.windows.ltsc2022
+++ b/docker/Dockerfile.windows.ltsc2022
@@ -17,7 +17,6 @@ FROM mcr.microsoft.com/powershell:windowsservercore-ltsc2022
 COPY --from=git /git /git
 
 COPY --from=git C:\Windows\System32\OpenSSH\ /openssh
-COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 
 ADD windows/* /bin/
 


### PR DESCRIPTION
Why was it working earlier?
We were using a docker delegate on aws vm to build dronegit image and the step, where it copies the dll file, was cached and hence it was never running.
We don't need to copy this dll file and it is already available in windowsservercore image
Have tested with a custom image, both http and ssh clones