### PR TITLE
[CI-13591]: add functionality to only copy file content

### DIFF
--- a/docker/Dockerfile.rootless.linux.amd64
+++ b/docker/Dockerfile.rootless.linux.amd64
@@ -5,7 +5,7 @@ RUN pip-3 install awscli
 RUN curl -L https://github.com/git-lfs/git-lfs/releases/download/v3.5.1/git-lfs-linux-amd64-v3.5.1.tar.gz > git-lfs.tar.gz \
     && tar -xvzf git-lfs.tar.gz && mv git-lfs-3.5.1/git-lfs /usr/local/bin/git-lfs
 
-ADD posix/clone posix/clone-commit posix/clone-pull-request posix/clone-tag posix/fixtures.sh posix/common posix/post-fetch /usr/local/bin/
+ADD posix/clone posix/clone-commit posix/clone-pull-request posix/clone-tag posix/fixtures.sh posix/common posix/post-fetch posix/copy-file-content /usr/local/bin/
 RUN chmod -R 777 /etc/ssh
 
 RUN microdnf install findutils

--- a/posix/clone
+++ b/posix/clone
@@ -2,8 +2,8 @@
 
 set -e
 
-# if PLUGIN_COPY_FILE_CONTENT is set, only copy the file content
-if [ "$PLUGIN_COPY_FILE_CONTENT" = "true" ]; then
+# if PLUGIN_ONLY_COPY_FILE_CONTENT is set, only copy the file content
+if [ "$PLUGIN_ONLY_COPY_FILE_CONTENT" = "true" ]; then
   if [ ! -z "$PLUGIN_OUTPUT_FILE_PATHS_CONTENT" ]; then
     for FILE_PATH in ${PLUGIN_OUTPUT_FILE_PATHS_CONTENT//,/ }; do
       FILE_CONTENT=$(<$FILE_PATH)

--- a/posix/clone
+++ b/posix/clone
@@ -2,17 +2,12 @@
 
 set -e
 
+chmod +x copy-file-content
+
 # if PLUGIN_ONLY_COPY_FILE_CONTENT is set, only copy the file content
 if [ "$PLUGIN_ONLY_COPY_FILE_CONTENT" = "true" ]; then
-  if [ ! -z "$PLUGIN_OUTPUT_FILE_PATHS_CONTENT" ]; then
-    for FILE_PATH in ${PLUGIN_OUTPUT_FILE_PATHS_CONTENT//,/ }; do
-      FILE_CONTENT=$(<$FILE_PATH)
-      FILE_CONTENT_BASE_64=`echo "$FILE_CONTENT" | base64`
-      FIXED_FILE_CONTENT=`echo $FILE_CONTENT_BASE_64 | tr = -`
-      echo "$FILE_PATH=$FIXED_FILE_CONTENT" >> $DRONE_OUTPUT
-    done
-  fi
-  exit 0
+	copy-file-content
+	exit 0
 fi
 
 # force the home directory path.
@@ -122,17 +117,4 @@ esac
 
 post-fetch
 
-if [ ! -z "$PLUGIN_OUTPUT_FILE_PATHS_CONTENT" ]
-then
-  for FILE_PATH in ${PLUGIN_OUTPUT_FILE_PATHS_CONTENT//,/ }
-  do
-      FILE_CONTENT=$(<$FILE_PATH)
-      FILE_CONTENT_BASE_64=`echo "$FILE_CONTENT" | base64`
-      # We are using github.com/joho/godotenv to fetch a map of env variables from plugins.
-      # It considers key2 as new env variable in the next yaml file content FILE_CONTENT="key1: value, key2: value". 
-      # Hence, we need to base64 encode file content and replace == with -- in encoded string, because the above lib doesn't allow ==
-      # while fetching a map of env variables from plugins.
-      FIXED_FILE_CONTENT=`echo $FILE_CONTENT_BASE_64 | tr = -`
-      echo "$FILE_PATH=$FIXED_FILE_CONTENT" >> $DRONE_OUTPUT
-  done
-fi
+copy-file-content

--- a/posix/clone
+++ b/posix/clone
@@ -2,8 +2,6 @@
 
 set -e
 
-chmod +x copy-file-content
-
 # if PLUGIN_ONLY_COPY_FILE_CONTENT is set, only copy the file content
 if [ "$PLUGIN_ONLY_COPY_FILE_CONTENT" = "true" ]; then
 	copy-file-content

--- a/posix/clone
+++ b/posix/clone
@@ -2,6 +2,19 @@
 
 set -e
 
+# if PLUGIN_COPY_FILE_CONTENT is set, only copy the file content
+if [ "$PLUGIN_COPY_FILE_CONTENT" = "true" ]; then
+  if [ ! -z "$PLUGIN_OUTPUT_FILE_PATHS_CONTENT" ]; then
+    for FILE_PATH in ${PLUGIN_OUTPUT_FILE_PATHS_CONTENT//,/ }; do
+      FILE_CONTENT=$(<$FILE_PATH)
+      FILE_CONTENT_BASE_64=`echo "$FILE_CONTENT" | base64`
+      FIXED_FILE_CONTENT=`echo $FILE_CONTENT_BASE_64 | tr = -`
+      echo "$FILE_PATH=$FIXED_FILE_CONTENT" >> $DRONE_OUTPUT
+    done
+  fi
+  exit 0
+fi
+
 # force the home directory path.
 if [ "$HOME" != "/home/drone" ]; then
 	if [ -d "/home/drone" ]; then

--- a/posix/copy-file-content
+++ b/posix/copy-file-content
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ ! -z "$PLUGIN_OUTPUT_FILE_PATHS_CONTENT" ]; then
+    for FILE_PATH in ${PLUGIN_OUTPUT_FILE_PATHS_CONTENT//,/ }; do
+      FILE_CONTENT=$(<$FILE_PATH)
+      FILE_CONTENT_BASE_64=`echo "$FILE_CONTENT" | base64`
+      FIXED_FILE_CONTENT=`echo $FILE_CONTENT_BASE_64 | tr = -`
+      echo "$FILE_PATH=$FIXED_FILE_CONTENT" >> $DRONE_OUTPUT
+    done
+fi


### PR DESCRIPTION
**Idea is to copy content of files (base64 encoded) given in inputs without cloning**

Our requirement is to fetch file content from pod/runner without cloning the repo.
At present a functionality is present (as mentioned by code at end of changed file), such that user can fetch file content but git clone is must.

In this pr, we are making change such that if env variable PLUGIN_ONLY_COPY_FILE_CONTENT is set true, then we will not do clone operation. And will just return the content of file given as plugin output variable 

## Tested 
1. git clone without the new var should clone the repo 
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/d709ee40-6bdd-4132-9ba0-15743729cc83">

2. git clone with new env var as false should clone the repo 

3. git clone with new env var as true should just copy the content 
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/aa5d505b-e95e-4b49-98c6-ec117eb39d1f">
 
