### PR TITLE
feat: [CI-13625]: Added flag for pr merge strategy

### DIFF
--- a/posix/clone-pull-request
+++ b/posix/clone-pull-request
@@ -27,7 +27,12 @@ set -e
 set -x
 
 git fetch ${FLAGS} origin +refs/heads/${DRONE_COMMIT_BRANCH}:
-git checkout ${targetRef}
+
+if [ "$DRONE_PR_MERGE_STRATEGY_BRANCH" = "true" ]; then
+  git checkout -b ${DRONE_COMMIT_BRANCH} origin/${DRONE_COMMIT_BRANCH}
+else
+  git checkout ${targetRef}
+fi
 
 git fetch origin ${DRONE_COMMIT_REF}:
 git merge ${DRONE_COMMIT_SHA}

--- a/windows/clone-pull-request.ps1
+++ b/windows/clone-pull-request.ps1
@@ -19,9 +19,14 @@ if ($Env:PLUGIN_PR_CLONE_STRATEGY -eq "SourceBranch") {
 sf -flags ${FLAGS} -ref "+refs/heads/${Env:DRONE_COMMIT_BRANCH}"
 
 if (Test-Path env:DRONE_COMMIT_BEFORE) {
-	# PR clone strategy is merge commit
-	Write-Host "+ git checkout ${Env:DRONE_COMMIT_BEFORE} -b ${Env:DRONE_COMMIT_BRANCH}"
-	iu git checkout ${Env:DRONE_COMMIT_BEFORE} -b ${Env:DRONE_COMMIT_BRANCH}
+	if ($env:DRONE_PR_MERGE_STRATEGY_BRANCH -eq "true") {
+		Write-Host "+ git checkout $Env:DRONE_COMMIT_BRANCH"
+		iu git checkout $Env:DRONE_COMMIT_BRANCH
+	} else {
+		# PR clone strategy is merge commit
+		Write-Host "+ git checkout ${Env:DRONE_COMMIT_BEFORE} -b ${Env:DRONE_COMMIT_BRANCH}"
+		iu git checkout ${Env:DRONE_COMMIT_BEFORE} -b ${Env:DRONE_COMMIT_BRANCH}
+	}
 } else {
 	Write-Host "+ git checkout $Env:DRONE_COMMIT_BRANCH"
 	iu git checkout $Env:DRONE_COMMIT_BRANCH


### PR DESCRIPTION
The api we are using for fetching codebase metadata for pr doesn't give updated commit details of base branch. 
Let’s say main has a commit c1, I raise a pr p1 with commit pc1. I raise another pr p2 with commit pc2.
I merge p2, now my main has commits c1 pc2 pc2merge.
Now if i fetch pr info from github about p1, the basecommit will be c1 only. But if I close and reopen the pr, then base commit fetched is pc2merge.
So, harness ci will work as expected if you are closing and reopening the pr. That’s why the inconsistency.
This is causing the customers to either close and reopen the pr or rebase it with main branch. 
To tackle this we are introducing this flag so that first target branch will be cloned and then we will merge the pr commits.