### PR TITLE
fix: [CI-14592]: fix windows ssh path

### DIFF
--- a/windows/clone.ps1
+++ b/windows/clone.ps1
@@ -31,7 +31,7 @@ if ($Env:DRONE_SSH_KEY) {
     # }
     # ssh-keyscan -H $Env:SSH_KEYSCAN_FLAGS $Env:DRONE_NETRC_MACHINE >  C:\\.ssh\\known_hosts
 
-    $Env:GIT_SSH_COMMAND="ssh -i C:\\.ssh\\id_rsa ${Env:SSH_KEYSCAN_FLAGS} -o StrictHostKeyChecking=no"
+    $Env:GIT_SSH_COMMAND="ssh -i C:/.ssh/id_rsa ${Env:SSH_KEYSCAN_FLAGS} -o StrictHostKeyChecking=no"
 }
 
 # configure git global behavior and parameters via the


### PR DESCRIPTION
path C:\\.ssh\\id_rsa  get escaped to C:.sshid_rsa  https://app.harness.io/ng/account/9UuUfLwaQ-6ZowvbG7qtLQ/module/ci/orgs/default/projects/RaghavTest/pipelines/gcdhgc/executions/D0wvgXXAShyKQsi-_IazeQ/pipeline?storeType=INLINE
hence putting C:/.ssh/d_rsa https://app.harness.io/ng/account/9UuUfLwaQ-6ZowvbG7qtLQ/module/ci/orgs/default/projects/RaghavTest/pipelines/gcdhgc/executions/6vHfRzYYSjuzih4kIqfoSg/pipeline?stage=BktwTXqmRMiuTU3Vf3Lz3A&step=3sXIrDErRiKeXlDouC9e9Q