### PR TITLE
fix: [CI-15499]: Add build tool and lang for telemetry

### DIFF
--- a/docker/Dockerfile.rootless.linux.amd64
+++ b/docker/Dockerfile.rootless.linux.amd64
@@ -6,7 +6,7 @@ RUN pip-3 install awscli
 RUN curl -L https://github.com/git-lfs/git-lfs/releases/download/v3.6.0/git-lfs-linux-amd64-v3.6.0.tar.gz > git-lfs.tar.gz \
     && tar -xvzf git-lfs.tar.gz && mv git-lfs-3.6.0/git-lfs /usr/local/bin/git-lfs
 
-ADD posix/clone posix/clone-commit posix/clone-pull-request posix/clone-tag posix/fixtures.sh posix/common posix/post-fetch posix/copy-file-content /usr/local/bin/
+ADD posix/clone posix/clone-commit posix/clone-pull-request posix/clone-tag posix/fixtures.sh posix/common posix/post-fetch posix/copy-file-content posix/get-buildtool-lang /usr/local/bin/
 RUN chmod -R 777 /etc/ssh
 
 RUN microdnf install findutils

--- a/posix/clone
+++ b/posix/clone
@@ -116,3 +116,7 @@ esac
 post-fetch
 
 copy-file-content
+
+if [ -n "$PLUGIN_BUILD_TOOL_FILE" ]; then
+	get-buildtool-lang || true
+fi

--- a/posix/clone
+++ b/posix/clone
@@ -117,6 +117,6 @@ post-fetch
 
 copy-file-content
 
-if [ -n "$PLUGIN_BUILD_TOOL_FILE" ]; then
-	get-buildtool-lang || true
+if [ -n "$PLUGIN_BUILD_TOOL_FILE" ] && [ -z "$CI_DISABLE_TELEMETRY" ]; then
+    get-buildtool-lang || true
 fi

--- a/posix/get-buildtool-lang
+++ b/posix/get-buildtool-lang
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+set -e
+
+# Define a list of language extensions
+detect_language() {
+    found_lang=""
+
+    # Define extensions for languages
+    case "$1" in
+        *.java) found_lang="Java" ;;
+        *.py) found_lang="Python" ;;
+        *.rb) found_lang="Ruby" ;;
+        *.go) found_lang="Golang" ;;
+        *.scala) found_lang="Scala" ;;
+        *.kt|*.kts) found_lang="Kotlin" ;;
+        *) found_lang="" ;;
+    esac
+    echo "$found_lang"
+}
+
+# Traverse the directory and detect languages
+found=""
+repo_path="./"
+for file in $(find "$repo_path" -type f 2>/dev/null | sort); do
+    lang=$(detect_language "$file")
+    if [ -n "$lang" ]; then
+        found="$lang"
+        break
+    fi
+done
+
+if [ -n "$found" ]; then
+    export HARNESS_LANG=$found
+fi
+
+
+#!/bin/bash
+
+# Define the list of build tools and their corresponding file patterns
+detect_build_tool() {
+    repo_path="$1"
+    build_tool=""
+
+    if [ -f "$repo_path/pom.xml" ]; then
+        build_tool="Maven"
+    elif [ -f "$repo_path/build.gradle" ]; then
+        build_tool="Gradle"
+    elif [ -f "$repo_path/package.json" ]; then
+        build_tool="Node"
+    elif [ -f "$repo_path/yarn.lock" ]; then
+        build_tool="Yarn"
+    elif [ -f "$repo_path/go.mod" ]; then
+        build_tool="Go"
+    elif [ -f "$repo_path/WORKSPACE" ]; then
+        build_tool="Bazel"
+    elif [ -f "$repo_path/*.csproj" ]; then
+        build_tool="Dotnet"
+    fi
+
+    echo "$build_tool"
+}
+
+
+HARNESS_BUILD_TOOL=$(detect_build_tool "$repo_path")
+
+# Create a JSON structure
+json_content=$(cat <<EOF
+{
+  "harness_lang": "$HARNESS_LANG",
+  "harness_build_tool": "$HARNESS_BUILD_TOOL"
+}
+EOF
+)
+
+  echo "$json_content" > "$PLUGIN_BUILD_TOOL_FILE"

--- a/posix/get-buildtool-lang
+++ b/posix/get-buildtool-lang
@@ -9,7 +9,7 @@ detect_languages() {
     detected_langs=""
 
     # Get all file extensions in the repository
-    files=$(find "$repo_path" -type f -not -path '*/\.*' 2>/dev/null | sed -E 's/.*\.(.*)$/\1/' | sort | uniq)
+    files=$(find "$repo_path" -type f -maxdepth 7 -not -path '*/\.*' 2>/dev/null | sed -E 's/.*\.(.*)$/\1/' | sort | uniq)
 
     # Process the langs variable without subshells
     lang_exts=$(echo "$langs" | tr ',' '\n')

--- a/posix/get-buildtool-lang
+++ b/posix/get-buildtool-lang
@@ -1,47 +1,44 @@
 #!/bin/sh
 
-set -e
+# Define language and their corresponding extensions using comma as delimiter
+langs="Java:java,Python:py,JavaScript:js,TypeScript:ts,C:c,C++:cpp,C++:cxx,C++:cc,CSharp:c#,CSharp:cs,PHP:php,Golang:go,Rust:rs,Kotlin:kt,Kotlin:kts,Lua:lua,Dart:dart,Ruby:rb,Swift:swift,R:r,VBScript:vb,Groovy:groovy,Scala:scala,Perl:pl,Godot:gd,Objective-C:m,Elixir:exs,Haskell:hs,Pascal:pas,Lisp:lisp,Lisp:cl,Lisp:clj,Lisp:cljs,Julia:jl,Zig:zig,Fortran:f,Solidity:sol,Ada:adb,Erlang:erl,Erlang:hrl,F#:fs,Apex:cls,Prolog:pro,OCaml:ml,COBOL:cbl,COBOL:cob,Crystal:cr,Nim:nim,Assembly:asm,VBA:vba,Shell:sh,Shell:bash,PowerShell:ps1,SQL:sql,HTML:html,HTML:htm,CSS:css"
 
-# Define a list of language extensions
-detect_language() {
-    found_lang=""
+# Function to detect languages based on file extensions in the given directory and its subdirectories
+detect_languages() {
+    repo_path="$1"
+    detected_langs=""
 
-    # Define extensions for languages
-    case "$1" in
-        *.java) found_lang="Java" ;;
-        *.py) found_lang="Python" ;;
-        *.rb) found_lang="Ruby" ;;
-        *.go) found_lang="Golang" ;;
-        *.scala) found_lang="Scala" ;;
-        *.kt|*.kts) found_lang="Kotlin" ;;
-        *) found_lang="" ;;
-    esac
-    echo "$found_lang"
+    # Get all file extensions in the repository
+    files=$(find "$repo_path" -type f -not -path '*/\.*' 2>/dev/null | sed -E 's/.*\.(.*)$/\1/' | sort | uniq)
+
+    # Process the langs variable without subshells
+    lang_exts=$(echo "$langs" | tr ',' '\n')
+    for lang_ext in $lang_exts; do
+        # Split the language and extension by the colon ':'
+        lang=$(echo "$lang_ext" | cut -d: -f1)
+        ext=$(echo "$lang_ext" | cut -d: -f2)
+
+        # Check if the extension is in the list of file extensions found in the repo
+        if echo "$files" | grep -qw "$ext"; then
+            # Add the language to the detected languages list
+            if [ -z "$detected_langs" ]; then
+                detected_langs="$lang"
+            else
+                detected_langs="$detected_langs,$lang"
+            fi
+        fi
+    done
+
+    # Output the detected languages
+    echo "$detected_langs"
 }
 
-# Traverse the directory and detect languages
-found=""
-repo_path="./"
-for file in $(find "$repo_path" -type f 2>/dev/null | sort); do
-    lang=$(detect_language "$file")
-    if [ -n "$lang" ]; then
-        found="$lang"
-        break
-    fi
-done
-
-if [ -n "$found" ]; then
-    export HARNESS_LANG=$found
-fi
-
-
-#!/bin/bash
-
-# Define the list of build tools and their corresponding file patterns
+# Function to detect build tools
 detect_build_tool() {
     repo_path="$1"
     build_tool=""
 
+    # Check for common build tool files
     if [ -f "$repo_path/pom.xml" ]; then
         build_tool="Maven"
     elif [ -f "$repo_path/build.gradle" ]; then
@@ -54,14 +51,19 @@ detect_build_tool() {
         build_tool="Go"
     elif [ -f "$repo_path/WORKSPACE" ]; then
         build_tool="Bazel"
-    elif [ -f "$repo_path/*.csproj" ]; then
+    elif [ -f "$repo_path"/*.csproj ]; then
         build_tool="Dotnet"
     fi
 
+    # Return the detected build tool
     echo "$build_tool"
 }
 
+# Define the repo path (default to current directory if not provided)
+repo_path="${1:-./}"
 
+# Detect languages and build tools
+HARNESS_LANG=$(detect_languages "$repo_path")
 HARNESS_BUILD_TOOL=$(detect_build_tool "$repo_path")
 
 # Create a JSON structure
@@ -73,4 +75,5 @@ json_content=$(cat <<EOF
 EOF
 )
 
-  echo "$json_content" > "$PLUGIN_BUILD_TOOL_FILE"
+# Output the JSON content to the specified file
+echo "$json_content" > "$PLUGIN_BUILD_TOOL_FILE"


### PR DESCRIPTION
Add logic for parsing language and build tool after cloning codebase.
check if env var PLUGIN_BUILD_TOOL_FILE is set then write the content to that file
Parse metrics as separate file to be parsed and sent as telemetry details in step response.