### PR TITLE
feat: [CI-15981]: use non-root user for drone-git docker image for wi…

### DIFF
--- a/docker/Dockerfile.windows.1809.rootless
+++ b/docker/Dockerfile.windows.1809.rootless
@@ -1,0 +1,35 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as core
+
+
+FROM mcr.microsoft.com/windows/servercore:1809 AS git
+SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.39.2.windows.1/MinGit-2.39.2-64-bit.zip -OutFile git.zip; `
+    Expand-Archive git.zip -DestinationPath C:\git;
+
+# Download and extract Git LFS (Updated to v3.6.0)
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-lfs/git-lfs/releases/download/v3.6.0/git-lfs-windows-amd64-v3.6.0.zip -OutFile git-lfs.zip; `
+    Expand-Archive git-lfs.zip -DestinationPath C:\git-lfs;
+
+RUN Add-WindowsCapability -Online -Name OpenSSH.Client*
+
+
+FROM mcr.microsoft.com/powershell:nanoserver-1809
+COPY --from=git /git /git
+COPY --from=git /git-lfs /git-lfs
+
+COPY --from=git C:\Windows\System32\OpenSSH\ /openssh
+COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
+
+ADD windows/* /bin/
+
+# https://github.com/PowerShell/PowerShell/issues/6211#issuecomment-367477137
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell;C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;C:\openssh;C:\git-lfs\git-lfs-3.6.0"
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+USER ContainerUser
+CMD [ "pwsh", "C:\\bin\\clone.ps1" ]

--- a/docker/Dockerfile.windows.ltsc2022.rootless
+++ b/docker/Dockerfile.windows.ltsc2022.rootless
@@ -1,0 +1,31 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS git
+SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.39.2.windows.1/MinGit-2.39.2-64-bit.zip -OutFile git.zip; `
+    Expand-Archive git.zip -DestinationPath C:\git;
+
+# Download and extract Git LFS
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-lfs/git-lfs/releases/download/v3.6.0/git-lfs-windows-amd64-v3.6.0.zip -OutFile git-lfs.zip; `
+    Expand-Archive git-lfs.zip -DestinationPath C:\git-lfs;
+
+RUN Add-WindowsCapability -Online -Name OpenSSH.Client*
+
+
+FROM mcr.microsoft.com/powershell:windowsservercore-ltsc2022
+COPY --from=git /git /git
+COPY --from=git /git-lfs /git-lfs
+
+COPY --from=git C:\Windows\System32\OpenSSH\ /openssh
+
+ADD windows/* /bin/
+
+# https://github.com/PowerShell/PowerShell/issues/6211#issuecomment-367477137
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell;C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;C:\openssh;C:\git-lfs\git-lfs-3.6.0"
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+USER ContainerUser
+CMD [ "pwsh", "C:\\bin\\clone.ps1" ]

--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -1,4 +1,4 @@
-image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-rootless
+image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-rootless
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,23 +7,23 @@ tags:
 {{/if}}
 manifests:
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64-rootless
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64-rootless
     platform:
       architecture: amd64
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64-rootless
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64-rootless
     platform:
       architecture: arm64
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64-rootless
     platform:
       architecture: amd64
       os: windows
       version: 1809
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64-rootless
     platform:
       architecture: amd64
       os: windows

--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -1,4 +1,4 @@
-image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-rootless
+image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-rootless
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,23 +7,23 @@ tags:
 {{/if}}
 manifests:
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64-rootless
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64-rootless
     platform:
       architecture: amd64
       os: linux
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64-rootless
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64-rootless
     platform:
       architecture: arm64
       os: linux
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64-rootless
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64-rootless
     platform:
       architecture: amd64
       os: windows
       version: 1809
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64-rootless
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64-rootless
     platform:
       architecture: amd64
       os: windows

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,54 +7,54 @@ tags:
 {{/if}}
 manifests:
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
     platform:
       variant: v7
       architecture: arm
       os: linux
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
     platform:
       variant: v6
       architecture: arm
       os: linux
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1803-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1803-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1803
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1809
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1903-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1903-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1903
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1909-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1909-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1909
   -
-    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64
     platform:
       architecture: amd64
       os: windows

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,54 +7,54 @@ tags:
 {{/if}}
 manifests:
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
     platform:
       variant: v7
       architecture: arm
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
     platform:
       variant: v6
       architecture: arm
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1803-amd64
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1803-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1803
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1809
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1903-amd64
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1903-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1903
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1909-amd64
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1909-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1909
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64
+    image: abhayganvir/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64
     platform:
       architecture: amd64
       os: windows


### PR DESCRIPTION
Added dockerfile for windows using non-root docker user.
Created the testing docker image using this pipeline: https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/PROD/projects/CI/pipelines/droneGit_AbhayTest/executions/F1zkjf3WQhOGsaFoLL7Fvw/pipeline?stage=8QoA9XdGQQuudZqJaJ473w

docker images: https://hub.docker.com/layers/abhayganvir/drone-git/1.6.7-debug-rootless/images/sha256-b2a53fec94d1de32262ca6fecc74271568073038b1ccb45989fcc6f2e626f4a8

release tag for testing: https://github.com/wings-software/drone-git/releases/tag/v1.6.7-debug

Verified the changes in devspace.
## For Windows
<img width="1726" alt="Screenshot 2025-02-03 at 4 43 42 PM" src="https://github.com/user-attachments/assets/cd53d75f-a56c-46c7-86e3-664710cf6499" />
<img width="1727" alt="Screenshot 2025-02-03 at 4 44 03 PM" src="https://github.com/user-attachments/assets/6ae04121-4271-482b-872a-a99ce819dd48" />
<img width="1728" alt="Screenshot 2025-02-03 at 4 44 14 PM" src="https://github.com/user-attachments/assets/39ecff75-cdb2-49c3-bddf-a8c006639b98" />

## For Linux
<img width="1727" alt="Screenshot 2025-02-03 at 4 44 25 PM" src="https://github.com/user-attachments/assets/276db7eb-f9ca-4d8c-ac7a-7dbeb3358aa2" />
<img width="1711" alt="Screenshot 2025-02-03 at 4 44 31 PM" src="https://github.com/user-attachments/assets/215aa213-1e87-4ff5-951e-3ac2fa316e14" />

