### PR TITLE
fix: [PIPE-25066]: Fix dubious ownership error and different remote url case

### DIFF
--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,54 +7,54 @@ tags:
 {{/if}}
 manifests:
   -
-    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
     platform:
       variant: v7
       architecture: arm
       os: linux
   -
-    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
     platform:
       variant: v6
       architecture: arm
       os: linux
   -
-    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1803-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1803-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1803
   -
-    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1809
   -
-    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1903-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1903-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1903
   -
-    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1909-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1909-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1909
   -
-    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64
+    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64
     platform:
       architecture: amd64
       os: windows

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,54 +7,54 @@ tags:
 {{/if}}
 manifests:
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64
+    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64
+    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
+    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
     platform:
       variant: v7
       architecture: arm
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
+    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-linux-arm
     platform:
       variant: v6
       architecture: arm
       os: linux
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1803-amd64
+    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1803-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1803
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64
+    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1809-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1809
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1903-amd64
+    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1903-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1903
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1909-amd64
+    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-1909-amd64
     platform:
       architecture: amd64
       os: windows
       version: 1909
   -
-    image: harness/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64
+    image: harnesscommunitytest/drone-git:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}-windows-ltsc2022-amd64
     platform:
       architecture: amd64
       os: windows

--- a/posix/common
+++ b/posix/common
@@ -8,9 +8,15 @@ fi
 
 if [ ! -d .git ]; then
   set -x
+  # /tmp/harness/stageId
   git init
   git config --global --add safe.directory '*'
   git remote add origin ${DRONE_REMOTE_URL}
+  set +x
+else
+  set -x
+  git config --global --add safe.directory '*'
+  git remote set-url origin ${DRONE_REMOTE_URL}
   set +x
 fi
 
@@ -47,3 +53,4 @@ if [ -n "$DRONE_NETRC_PRE_FETCH" ]; then
     eval "$line"
   done
 fi
+

--- a/posix/common
+++ b/posix/common
@@ -1,5 +1,18 @@
 #!/bin/sh
 
+# Function to update the origin URL for git remote
+update_origin_url() {
+  local origin_url=$1
+  # Check if the 'origin' remote exists
+  if git remote get-url origin &>/dev/null; then
+    # If 'origin' exists, update its URL
+    git remote set-url origin "${origin_url}"
+  else
+    # If 'origin' doesn't exist, add it
+    git remote add origin "${origin_url}"
+  fi
+}
+
 if [ "$DRONE_NETRC_DEBUG" = "true" ]; then
   export GIT_CURL_VERBOSE=1
   export GIT_TRACE=1
@@ -14,8 +27,8 @@ if [ ! -d .git ]; then
   set +x
 else
   set -x
-  git config --global --add safe.directory '*'
-  git remote set-url origin ${DRONE_REMOTE_URL}
+  git config --local --add safe.directory '*'
+  update_origin_url ${DRONE_REMOTE_URL}
   set +x
 fi
 

--- a/posix/common
+++ b/posix/common
@@ -27,7 +27,7 @@ if [ ! -d .git ]; then
   set +x
 else
   set -x
-  git config --local --add safe.directory '*'
+  git config --gobal --add safe.directory '*'
   update_origin_url ${DRONE_REMOTE_URL}
   set +x
 fi

--- a/posix/common
+++ b/posix/common
@@ -8,7 +8,6 @@ fi
 
 if [ ! -d .git ]; then
   set -x
-  # /tmp/harness/stageId
   git init
   git config --global --add safe.directory '*'
   git remote add origin ${DRONE_REMOTE_URL}
@@ -53,4 +52,3 @@ if [ -n "$DRONE_NETRC_PRE_FETCH" ]; then
     eval "$line"
   done
 fi
-

--- a/posix/common
+++ b/posix/common
@@ -27,7 +27,7 @@ if [ ! -d .git ]; then
   set +x
 else
   set -x
-  git config --gobal --add safe.directory '*'
+  git config --global --add safe.directory '*'
   update_origin_url ${DRONE_REMOTE_URL}
   set +x
 fi

--- a/windows/common.ps1
+++ b/windows/common.ps1
@@ -20,8 +20,8 @@ if (!(Test-Path .git)) {
     Write-Host "+ git remote add origin $Env:DRONE_REMOTE_URL"
     iu git remote add origin $Env:DRONE_REMOTE_URL
 } else {
-    Write-Host "+ git config --local --add safe.directory *"
-    iu git config --local --add safe.directory '*'
+    Write-Host "+ git config --global --add safe.directory *"
+    iu git config --global --add safe.directory '*'
 
     Set-OriginUrl -originUrl $Env:DRONE_REMOTE_URL
 

--- a/windows/common.ps1
+++ b/windows/common.ps1
@@ -4,6 +4,24 @@
 Set-Alias iu Invoke-Utility
 Set-Alias sf Start-Fetch
 
+function Set-OriginUrl {
+    param (
+        [string]$originUrl
+    )
+    # Check if the remote 'origin' exists
+    $originExists = git remote get-url origin -ErrorAction SilentlyContinue
+
+    if ($originExists) {
+        # If 'origin' exists, update its URL
+        Write-Host "+ git remote set-url origin $originUrl"
+        iu git remote set-url origin $originUrl
+    } else {
+        # If 'origin' doesn't exist, add it
+        Write-Host "+ git remote add origin $originUrl"
+        iu git remote add origin $originUrl
+    }
+}
+
 if ($Env:DRONE_NETRC_DEBUG) {
     $Env:GIT_CURL_VERBOSE = 1
     $Env:GIT_TRACE = 1
@@ -57,23 +75,5 @@ if (-not [string]::IsNullOrEmpty($env:DRONE_NETRC_PRE_FETCH)) {
     foreach ($line in $lines) {
         Write-Host "+ $line"
         Invoke-Expression $line
-    }
-}
-
-function Set-OriginUrl {
-    param (
-        [string]$originUrl
-    )
-    # Check if the remote 'origin' exists
-    $originExists = git remote get-url origin -ErrorAction SilentlyContinue
-
-    if ($originExists) {
-        # If 'origin' exists, update its URL
-        Write-Host "+ git remote set-url origin $originUrl"
-        iu git remote set-url origin $originUrl
-    } else {
-        # If 'origin' doesn't exist, add it
-        Write-Host "+ git remote add origin $originUrl"
-        iu git remote add origin $originUrl
     }
 }

--- a/windows/common.ps1
+++ b/windows/common.ps1
@@ -9,7 +9,7 @@ function Set-OriginUrl {
         [string]$originUrl
     )
     # Check if the remote 'origin' exists
-    $originExists = git remote get-url origin -ErrorAction SilentlyContinue
+    $originExists = git remote get-url origin
 
     if ($originExists) {
         # If 'origin' exists, update its URL

--- a/windows/common.ps1
+++ b/windows/common.ps1
@@ -20,12 +20,10 @@ if (!(Test-Path .git)) {
     Write-Host "+ git remote add origin $Env:DRONE_REMOTE_URL"
     iu git remote add origin $Env:DRONE_REMOTE_URL
 } else {
-    Write-Host "+ git config --global --add safe.directory *"
-    iu git config --global --add safe.directory '*'
+    Write-Host "+ git config --local --add safe.directory *"
+    iu git config --local --add safe.directory '*'
 
-    Write-Host "+ git remote set-url origin $Env:DRONE_REMOTE_URL"
-    iu git remote set-url origin $Env:DRONE_REMOTE_URL
-}
+    Set-OriginUrl -originUrl $Env:DRONE_REMOTE_URL
 
 if ($env:DRONE_NETRC_LFS_ENABLED -eq "true") {
     Write-Host "+ git lfs install"
@@ -58,5 +56,23 @@ if (-not [string]::IsNullOrEmpty($env:DRONE_NETRC_PRE_FETCH)) {
     foreach ($line in $lines) {
         Write-Host "+ $line"
         Invoke-Expression $line
+    }
+}
+
+function Set-OriginUrl {
+    param (
+        [string]$originUrl
+    )
+    # Check if the remote 'origin' exists
+    $originExists = git remote get-url origin -ErrorAction SilentlyContinue
+
+    if ($originExists) {
+        # If 'origin' exists, update its URL
+        Write-Host "+ git remote set-url origin $originUrl"
+        iu git remote set-url origin $originUrl
+    } else {
+        # If 'origin' doesn't exist, add it
+        Write-Host "+ git remote add origin $originUrl"
+        iu git remote add origin $originUrl
     }
 }

--- a/windows/common.ps1
+++ b/windows/common.ps1
@@ -24,6 +24,7 @@ if (!(Test-Path .git)) {
     iu git config --global --add safe.directory '*'
 
     Set-OriginUrl -originUrl $Env:DRONE_REMOTE_URL
+}
 
 if ($env:DRONE_NETRC_LFS_ENABLED -eq "true") {
     Write-Host "+ git lfs install"

--- a/windows/common.ps1
+++ b/windows/common.ps1
@@ -13,12 +13,18 @@ if ($Env:DRONE_NETRC_DEBUG) {
 if (!(Test-Path .git)) {
     Write-Host '+ git init';
     iu git init
-    
+
     Write-Host "+ git config --global --add safe.directory *"
     iu git config --global --add safe.directory '*'
-    
+
     Write-Host "+ git remote add origin $Env:DRONE_REMOTE_URL"
     iu git remote add origin $Env:DRONE_REMOTE_URL
+} else {
+    Write-Host "+ git config --global --add safe.directory *"
+    iu git config --global --add safe.directory '*'
+
+    Write-Host "+ git remote set-url origin $Env:DRONE_REMOTE_URL"
+    iu git remote set-url origin $Env:DRONE_REMOTE_URL
 }
 
 if ($env:DRONE_NETRC_LFS_ENABLED -eq "true") {


### PR DESCRIPTION
In this PR, we fix 2 issues we found with using the drone-git plugin in Harness `clone` steps with the new unified runner.

These issues happen in case of a stage with 2 subsequent Harness git clone steps.

**ISSUE 1 (only happens in docker setup using Rancher/Colima):**

Our drone-git container is started with root user. But the files created by the container, in a volume shared with the host machine, have the “501” user as owner instead of root user ((only in Rancher/Colima case, which uses lima-vm under the hood).

Because we only call `git config --global --add safe.directory '*'` on the first git clone step, the second one fails with the "Dubious ownership error" (container is using `root` user while .git file is owned by "501" user):
![image](https://github.com/user-attachments/assets/17dd1459-df63-4fe7-a85a-dfb2bc2191cb)

**Fix**: Always call `git config --global --add safe.directory '*'`, even if the folder already contains a `.git`, because the global git configs don't persist across different steps.

**ISSUE 2 (general issue in Git Clone step with unified runner):**

The current docker runner (harness-docker-runner) has a “stateful” behavior for environment variables passed to containers. That is, the environment variables coming in the init step of a stage are passed to all the subsequent container steps in the same stage. Furthermore, the environment variables for the “implicit” git clone step come in the init step’s env variables in the old CI flow (not using the new unified runner).

The unified runner doesn't pass env variables from init step to other steps (by design). In the unified runner implementation, each step is supposed to run with its own environment variables.

However, this creates a problem when using `drone-git` plugin. Suppose you have 2 git clone steps (first implicit, second explicit):
- Step 1 (Implicit Git clone): Remote URL `git@github.com:wings-software/springboot.git`, uses SSH creds.
- Step 2 (Explicit Git clone): Remote URL `https://github.com/wings-software/springboot`, uses HTTP creds.

Then Step 2 will fail because we don't call `git remote set-url origin ${DRONE_REMOTE_URL}` for the second step, and the container wrongly tries to use the SSH URL with HTTP credentials.

This doesn't happen in harness-docker-runner because we are passing the SSH creds as env vars that came in Init step to Step 2, so it actually succeeds using the SSH URL.

**Fix**: Call `git remote set-url origin ${DRONE_REMOTE_URL}` if the current folder is an already initialized git repo, setting the correct git remote url that came in step's env variables.

**TESTING**:
2 Subsequent Git Clone steps working fine when codebase is using SSH creds and explicit clone step is using HTTP creds, and Docker setup with Rancher Desktop:
<img width="2451" alt="image" src="https://github.com/user-attachments/assets/e1a3d8ce-27f4-4f92-b2a7-3cc85156d333" />

**AUTOMATION RESULTS**:
I've ran automation using the plugin tag `1.6.7-debug` with delegate and local harness-docker-runner. Here are the results:
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/c028fb8a-b31f-4bcb-b9f8-575fb8ff02df" />
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/26961bc5-7985-4c3f-8a44-a33d7de5a661" />

Among the test failures, these are unrelated with Git Clone (they failed due to Rancher desktop's behavior on MacOS):
- run-environment-success : Related to Rancher desktop behavior on local (no Git Clone Step). 
- run-output-variable-success : Related to Rancher desktop behavior on local (no Git Clone step).
- mongo-success-background-step : Related to Rancher desktop behavior on local (no Git Clone step).
- redis-success-background-step : Related to Rancher desktop behavior on local (no Git Clone Step).

These other two are related to Git Clone, but their failures are acceptable. Here is the explanation:
- codebase-gitlab-branch-repo-ssh-and-clonestep-bitbucket-branch-repo-ssh : This test is *broken* and also fails with delegate +  local harness-docker-runner . It is trying executing 2 subsequent git clone steps (branch operation), using 2 different repo URLs and credentials. See the pipeline's yaml here, in the Automation repo: `CI/src/main/resources/common/ci/testcases/k8/windows/gitClone/git-clone-step-branch-and-codebase-branch.yml`
- clonestep-x2-same-repo-different-scm-fail : In our automation, this pipeline execution is supposed to fail, but after our changes in this PR, the execution succeeds. This pipeline runs 2 subsequent Git Clone steps, for fetching the same tag `v0.1`. The repos are the same, but from 2 different remotes (1st is Gitlab, 2nd is Github). Before our changes, the second Git Clone Step throws `fatal: Could not read from remote repository`. This is because this command is not called in the 2nd Git Clone step `git remote set-url origin git@github.com:wings-software/springboot.git`. Thus we are trying to fetch tags from Gitlab (1st Git Clone step) using Gitlab's credentials, and the execution fails. After our change in this PR, we are now setting the origin URL to be Github, so the tag fetching works as expected. For reference, see the pipeline's yaml here, in Automation repo: `GeneralUtils/src/main/resources/common/ci/testcases/vm/linux/gitClone/git-clonestep-tag-and-clonestep-tag.yml`

**TESTING ON WINDOWS**:
Tested a pipeline with 2 subsequent git clone steps with unified runner on Windows. It is working fine:
<img width="2457" alt="image" src="https://github.com/user-attachments/assets/e28a5f76-66a1-4cfd-b7b8-fbb7586ea20b" />
<img width="2449" alt="image" src="https://github.com/user-attachments/assets/7a54831f-72bd-4338-8e1d-ffdc81be6af6" />

Case where no "origin" remote is present in the git repo (plugin calls `git remote add origin URL`):
<img width="2443" alt="image" src="https://github.com/user-attachments/assets/b94e8945-908c-4f33-92ef-95fe95def3c8" />

Case where "origin" remote has a different URL than what came as input to the plugin (plugin calls `git remote set-url origin URL`):
<img width="2431" alt="image" src="https://github.com/user-attachments/assets/ae17c580-0df7-47be-8056-a2be386703f3" />




