### PR TITLE
Ci 18088 adding git auth develop

### DIFF
--- a/windows/clone.ps1
+++ b/windows/clone.ps1
@@ -21,6 +21,22 @@ password $Env:DRONE_NETRC_PASSWORD
 "@ > (Join-Path $Env:USERPROFILE '_netrc');
 }
 
+if ($Env:DRONE_PERSIST_CREDS) {
+    # Define the path to the file in the current user's profile
+    $sourcePath = Join-Path $Env:USERPROFILE '_netrc';
+    
+    # Define the destination path in the shared volume
+    $destinationPath = 'C:\addon\shared\_netrc';
+
+    # Ensure the parent directory for the destination exists
+    New-Item -ItemType Directory -Path (Split-Path $destinationPath) -Force;
+    
+    # Check if the file was created and then copy it to the shared volume
+    if (Test-Path -Path $sourcePath) {
+        Copy-Item -Path $sourcePath -Destination $destinationPath -Force;
+    }
+}
+
 if ($Env:DRONE_SSH_KEY) {
     mkdir C:\.ssh  -Force
     echo $Env:DRONE_SSH_KEY > C:\.ssh\id_rsa

--- a/windows/clone.ps1
+++ b/windows/clone.ps1
@@ -22,16 +22,9 @@ password $Env:DRONE_NETRC_PASSWORD
 }
 
 if ($Env:DRONE_PERSIST_CREDS) {
-    # Define the path to the file in the current user's profile
     $sourcePath = Join-Path $Env:USERPROFILE '_netrc';
-    
-    # Define the destination path in the shared volume
     $destinationPath = 'C:\addon\shared\_netrc';
-
-    # Ensure the parent directory for the destination exists
     New-Item -ItemType Directory -Path (Split-Path $destinationPath) -Force;
-    
-    # Check if the file was created and then copy it to the shared volume
     if (Test-Path -Path $sourcePath) {
         Copy-Item -Path $sourcePath -Destination $destinationPath -Force;
     }


### PR DESCRIPTION
We want to enable authenticated Git operations (like push or fetch) in later Run steps of a pipeline.
The drone-git plugin already stores Git credentials in a .netrc file during the initial clone step.
Our goal is to share this .netrc file with all containers in the Pod.
To do this have to copy _netrc to shared directory
<img width="1728" height="1117" alt="Screenshot 2025-08-04 at 3 16 16 PM" src="https://github.com/user-attachments/assets/eea7bd2c-7b89-4177-95ff-38cf903607dc" />
<img width="1728" height="1117" alt="Screenshot 2025-08-04 at 3 16 19 PM" src="https://github.com/user-attachments/assets/d8939726-66b0-482f-bc97-cdc03efcc942" />
