### PR TITLE
fix: [CI-22696]: propagate drone-git.exe exit code through Windows clone.ps1 wrapper

### DIFF
--- a/docker/Dockerfile.windows.1803
+++ b/docker/Dockerfile.windows.1803
@@ -27,7 +27,7 @@ RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell;C:\git-lfs\git-lfs-3.7.1"
 COPY release/windows/amd64/drone-git.exe /bin/drone-git.exe
 
 # Create wrapper script that calls the enhanced binary for backward compatibility
-RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args'"
+RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args; exit $LASTEXITCODE'"
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 # Use old entrypoint for backward compatibility (now calls enhanced binary)
 CMD ["pwsh", "C:\\bin\\clone.ps1"]

--- a/docker/Dockerfile.windows.1809
+++ b/docker/Dockerfile.windows.1809
@@ -37,7 +37,7 @@ RUN pwsh -Command "New-Item -ItemType Directory -Force -Path 'C:\bin' | Out-Null
 COPY release/windows/amd64/drone-git.exe /bin/drone-git.exe
 
 # Create wrapper script that calls the enhanced binary for backward compatibility
-RUN pwsh -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value 'C:\bin\drone-git.exe `$args'"
+RUN pwsh -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args; exit $LASTEXITCODE'"
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 # Use old entrypoint for backward compatibility (now calls enhanced binary)
 CMD ["pwsh", "C:\\bin\\clone.ps1"]

--- a/docker/Dockerfile.windows.1809.rootless
+++ b/docker/Dockerfile.windows.1809.rootless
@@ -35,7 +35,7 @@ RUN pwsh -Command "New-Item -ItemType Directory -Force -Path 'C:\bin' | Out-Null
 COPY release/windows/amd64/drone-git.exe /bin/drone-git.exe
 
 # Create wrapper script that calls the enhanced binary for backward compatibility
-RUN pwsh -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value 'C:\bin\drone-git.exe `$args'"
+RUN pwsh -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args; exit $LASTEXITCODE'"
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 USER ContainerUser
 # Use old entrypoint for backward compatibility (now calls enhanced binary)

--- a/docker/Dockerfile.windows.1903
+++ b/docker/Dockerfile.windows.1903
@@ -27,7 +27,7 @@ RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell;C:\git-lfs\git-lfs-3.7.1"
 COPY release/windows/amd64/drone-git.exe /bin/drone-git.exe
 
 # Create wrapper script that calls the enhanced binary for backward compatibility
-RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args'"
+RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args; exit $LASTEXITCODE'"
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 # Use old entrypoint for backward compatibility (now calls enhanced binary)
 CMD ["pwsh", "C:\\bin\\clone.ps1"]

--- a/docker/Dockerfile.windows.1909
+++ b/docker/Dockerfile.windows.1909
@@ -26,7 +26,7 @@ RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell;C:\git-lfs\git-lfs-3.7.1"
 COPY release/windows/amd64/drone-git.exe /bin/drone-git.exe
 
 # Create wrapper script that calls the enhanced binary for backward compatibility
-RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args'"
+RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args; exit $LASTEXITCODE'"
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 # Use old entrypoint for backward compatibility (now calls enhanced binary)
 CMD ["pwsh", "C:\\bin\\clone.ps1"]

--- a/docker/Dockerfile.windows.ltsc2022
+++ b/docker/Dockerfile.windows.ltsc2022
@@ -31,7 +31,7 @@ RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell;C:\git\cmd;C:\git\mingw64\b
 COPY release/windows/amd64/drone-git.exe /bin/drone-git.exe
 
 # Create wrapper script that calls the enhanced binary for backward compatibility
-RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args'"
+RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args; exit $LASTEXITCODE'"
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 # Keep old entrypoint format for backward compatibility
 # Users must explicitly change to drone-git.exe to get enhanced features

--- a/docker/Dockerfile.windows.ltsc2022.rootless
+++ b/docker/Dockerfile.windows.ltsc2022.rootless
@@ -27,7 +27,7 @@ COPY --from=git C:\Windows\System32\OpenSSH\ /openssh
 COPY release/windows/amd64/drone-git.exe /bin/drone-git.exe
 
 # Create wrapper script that calls the enhanced binary for backward compatibility
-RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args'"
+RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args; exit $LASTEXITCODE'"
 
 # https://github.com/PowerShell/PowerShell/issues/6211#issuecomment-367477137
 USER ContainerAdministrator

--- a/docker/Dockerfile.windows.ltsc2025
+++ b/docker/Dockerfile.windows.ltsc2025
@@ -64,7 +64,7 @@ ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 COPY release/windows/amd64/drone-git.exe /bin/drone-git.exe
 
 # Create wrapper script that calls the enhanced binary for backward compatibility
-RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args'"
+RUN powershell -Command "Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args; exit $LASTEXITCODE'"
 SHELL ["C:\\Program Files\\PowerShell\\latest\\pwsh.exe", "-NoLogo", "-Command", "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue';"]
 
 # Use old entrypoint for backward compatibility (now calls enhanced binary)

--- a/docker/Dockerfile.windows.ltsc2025.rootless
+++ b/docker/Dockerfile.windows.ltsc2025.rootless
@@ -55,7 +55,7 @@ ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 COPY release/windows/amd64/drone-git.exe /bin/drone-git.exe
 
 # Create wrapper script that calls the enhanced binary for backward compatibility
-RUN Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args'
+RUN Set-Content -Path 'C:\bin\clone.ps1' -Value '& C:\bin\drone-git.exe @args; exit $LASTEXITCODE'
 SHELL ["C:\\Program Files\\PowerShell\\latest\\pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 USER ContainerUser
 # Use old entrypoint for backward compatibility (now calls enhanced binary)


### PR DESCRIPTION
On Windows pipelines using the V1 gitCloneStep template, when git fetch failed inside the drone-git container (for example, exit code 128 due to repository-not-found or authentication failures), the step was incorrectly marked as SUCCESS and the pipeline continued execution.
The issue reproduces on both:

V1 Windows Local Infrastructure (VM)
V1 Windows Kubernetes
Root Cause
The Windows drone-git container uses a clone.ps1 wrapper script generated during image build. The script was:
& C:\bin\drone-git.exe @argsThe script invoked drone-git.exe using PowerShell's call operator (&) but did not propagate the process exit code. As a result:

drone-git.exe could fail with a non-zero exit code.
clone.ps1 would still exit with code 0.
The container would exit successfully.
The V1 step handler would mark the step as PASSED, regardless of the actual clone result.
The Linux implementation is not affected. Linux images use:
ENTRYPOINT ["/usr/local/bin/clone"]where clone is a direct symlink to the drone-git binary, ensuring the binary's exit code becomes the container's exit code.
Fix
Updated the wrapper script generation in all nine Windows Dockerfiles (commit ad57fcc) to explicitly propagate the exit code.
Before
& C:\bin\drone-git.exe @argsAfter
& C:\bin\drone-git.exe @args; exit $LASTEXITCODEFiles Updated

docker/Dockerfile.windows.1803
docker/Dockerfile.windows.1809
docker/Dockerfile.windows.1809.rootless
docker/Dockerfile.windows.1903
docker/Dockerfile.windows.1909
docker/Dockerfile.windows.ltsc2022
docker/Dockerfile.windows.ltsc2022.rootless
docker/Dockerfile.windows.ltsc2025
docker/Dockerfile.windows.ltsc2025.rootless
Test Plan
• V1 Windows Local Infrastructure (VM)
Original passing pipeline: [https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/CITestDemoOrgvloHf[…]40cfzIfQ&stage=Auyc7yq6Tk-IYPoCExpzzw&childStage=&stageExecId=](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/CITestDemoOrgvloHfSVJAc/projects/CITestDemoProwvLGkeyPfm/pipelines/CITestUnifiedV1Barrierqt3qLqLxCZ/executions/Q7efBob2SoyaBaeZkJRarw/pipeline?storeType=INLINE&step=q5GylQ_ARSiPVw40cfzIfQ&stage=Auyc7yq6Tk-IYPoCExpzzw&childStage=&stageExecId=)
• V1 Windows Kubernetes
originally passing: [https://qa.harness.io/ng/account/n0zDK8DRTv2kcwuGq3Y_nA/all/orgs/CITestDemoOrgGSG48[…]zCuLFejw&stage=rre6AGLbSVmiVLl38C9ekQ&childStage=&stageExecId=](https://qa.harness.io/ng/account/n0zDK8DRTv2kcwuGq3Y_nA/all/orgs/CITestDemoOrgGSG48okbTx/projects/CITestDemoProGu8mnMS7od/pipelines/CIK8UnifiedtK5qMjY8iJ/executions/Kr-YevRHQ4WRjAVYXhK1SQ/pipeline?step=q9UmUAXnRm2Mo2zCuLFejw&stage=rre6AGLbSVmiVLl38C9ekQ&childStage=&stageExecId=)

Correctly failing: [http://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/D[…]slocalinfragitclone/executions/THUATkgWTX2vjWRznbmOyA/pipeline](http://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Devansh_Test/pipelines/windowslocalinfragitclone/executions/THUATkgWTX2vjWRznbmOyA/pipeline)
Tested with image devanshmathur19/drone-git@sha256:341b3ea158bda3bea5bea8bd295ed6766e155c3f9c8556b1e156ec722303e7a7